### PR TITLE
Pipeline CI/CD (tests + build + deploy a EC2 vía SSM) — Curro Martínez Hidalgo

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,0 +1,31 @@
+name: Backend CI/CD
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+defaults:
+  run:
+    working-directory: backend
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -57,3 +57,66 @@ jobs:
         with:
           name: backend-dist
           path: backend/dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: .
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Send SSM deploy command
+        id: ssm
+        env:
+          INSTANCE_ID: ${{ secrets.EC2_INSTANCE_ID }}
+        run: |
+          CMD_ID=$(aws ssm send-command \
+            --document-name "AWS-RunShellScript" \
+            --instance-ids "$INSTANCE_ID" \
+            --parameters 'commands=["cd /home/ssm-user/AI4Devs-pipeline","git fetch origin","git checkout ${{ github.head_ref }}","git pull origin ${{ github.head_ref }}","cd backend","npm ci","npx prisma generate","npm run build","pm2 restart lti-backend"]' \
+            --query 'Command.CommandId' \
+            --output text)
+          echo "SSM Command ID: $CMD_ID"
+          echo "command-id=$CMD_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for deploy to complete
+        env:
+          INSTANCE_ID: ${{ secrets.EC2_INSTANCE_ID }}
+          CMD_ID: ${{ steps.ssm.outputs.command-id }}
+        run: |
+          for i in $(seq 1 30); do
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id "$CMD_ID" \
+              --instance-id "$INSTANCE_ID" \
+              --query 'Status' \
+              --output text 2>/dev/null || echo "Pending")
+            echo "Attempt $i/30: $STATUS"
+            case "$STATUS" in
+              Success)
+                echo "Deploy completed successfully"
+                exit 0
+                ;;
+              Failed|Cancelled|TimedOut|Undeliverable)
+                echo "--- SSM stderr ---"
+                aws ssm get-command-invocation \
+                  --command-id "$CMD_ID" \
+                  --instance-id "$INSTANCE_ID" \
+                  --query 'StandardErrorContent' \
+                  --output text || true
+                echo "Deploy failed with status: $STATUS"
+                exit 1
+                ;;
+            esac
+            sleep 10
+          done
+          echo "Timed out waiting for SSM command (300 s)"
+          exit 1

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -29,3 +29,31 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Compile TypeScript
+        run: npm run build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-dist
+          path: backend/dist

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,103 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+LTI (Talent Tracking System) is a full-stack ATS (Applicant Tracking System) with:
+- **Backend**: Node.js + Express + TypeScript, using Prisma ORM with PostgreSQL
+- **Frontend**: React (JavaScript/TypeScript mix), bootstrapped with Create React App
+- **Database**: PostgreSQL via Docker
+
+Backend runs on `http://localhost:3010`, frontend on `http://localhost:3000`.
+
+## Commands
+
+### Backend (`cd backend`)
+```sh
+npm run dev          # Development with hot reload (ts-node-dev)
+npm run build        # Compile TypeScript → dist/
+npm start            # Run compiled dist/index.js
+npm test             # Run Jest tests
+npm run prisma:generate  # Regenerate Prisma client after schema changes
+```
+
+Run a single test file:
+```sh
+npx jest src/application/services/candidateService.test.ts
+```
+
+Prisma database setup (from `backend/`):
+```sh
+npx prisma migrate dev
+ts-node prisma/seed.ts
+```
+
+### Frontend (`cd frontend`)
+```sh
+npm start            # Dev server
+npm run build        # Production build
+npm test             # Jest tests
+npm run cypress:open # Cypress E2E (interactive)
+npm run cypress:run  # Cypress E2E (headless)
+```
+
+### Infrastructure (root)
+```sh
+docker-compose up -d    # Start PostgreSQL container
+docker-compose down     # Stop container
+```
+
+## Architecture
+
+### Backend (DDD layered architecture)
+
+```
+backend/src/
+├── index.ts                    # Express app entry point, middleware setup
+├── routes/                     # Route definitions (candidateRoutes, positionRoutes)
+├── presentation/controllers/   # HTTP controllers — parse req/res, call services
+├── application/services/       # Use cases / application logic
+│   └── validator.ts            # Input validation
+├── domain/models/              # Domain entities (Candidate, Position, Application, etc.)
+└── infrastructure/             # (implied by Prisma) — data access
+```
+
+Domain models (`domain/models/`) encapsulate business logic and map directly to Prisma schema entities: `Candidate`, `Education`, `WorkExperience`, `Resume`, `Company`, `Employee`, `Position`, `Application`, `InterviewFlow`, `InterviewStep`, `InterviewType`, `Interview`.
+
+The `Candidate` aggregate root owns `Education`, `WorkExperience`, `Resume`, and `Application`.
+
+`PrismaClient` is attached to every Express request via middleware in `index.ts` (`req.prisma`), making it available in controllers without direct imports.
+
+### Frontend
+
+```
+frontend/src/
+├── App.js                      # Root component with React Router routes
+├── components/                 # Feature components (Positions, PositionDetails, RecruiterDashboard, etc.)
+└── services/candidateService.js # API client calls to backend
+```
+
+Uses React Bootstrap for UI, `react-beautiful-dnd` / `react-dnd` for drag-and-drop (Kanban board for candidate pipeline stages).
+
+### Key design constraints (from ManifestoBuenasPracticas.md)
+
+- Follow DDD: domain logic lives in `domain/models/`, not in controllers or routes
+- Apply SOLID principles: SRP per class, use repositories to abstract data access
+- Avoid repeating validation or DB logic — centralize in domain models or services
+- New routes should follow the pattern in `backend/src/prompts/CreateNewRoute.md`
+
+## Environment
+
+Root `.env` defines DB credentials used by `docker-compose.yml`. Backend `backend/.env` should contain `DATABASE_URL`. The Prisma schema currently hard-codes a connection string — prefer using the `DATABASE_URL` env var via `backend/.env`.
+
+## API Reference
+
+Full OpenAPI spec: `backend/api-spec.yaml`  
+Data model diagram: `backend/ModeloDatos.md`
+
+## CI / Deployment
+
+GitHub Actions workflow is at `.github/workflows/ci.yml` (currently empty — this is the task for this branch).
+
+Production targets an EC2 instance. Required GitHub secrets: `AWS_ACCESS_ID`, `AWS_ACCESS_KEY`, `EC2_INSTANCE`.

--- a/prompts/prompts-CMH.md
+++ b/prompts/prompts-CMH.md
@@ -52,3 +52,40 @@ proyecto antes de generar el pipeline, para no repetir el contexto en cada promp
 Genera `CLAUDE.md` en la raíz con las secciones Commands, Architecture y CI/CD.
 Validado correctamente: detecta backend Node+TS+Prisma+Jest, build `npm run build`,
 te
+
+## 1. Trigger del workflow + Job de Tests
+
+**Objetivo:** crear `.github/workflows/pipeline.yml` con el trigger correcto
+(push a rama con PR abierto) y un job que ejecute los tests del backend, ya con
+buenas prácticas de legibilidad y robustez.
+
+**Prompt (estructura Goal / Return Format / Warnings / Requisitos de calidad / Context):**
+> GOAL
+> Crea un workflow de GitHub Actions en `.github/workflows/pipeline.yml` que se
+> dispare al hacer push de commits a una rama con un Pull Request abierto, y que
+> ejecute la suite de tests del backend.
+>
+> RETURN FORMAT
+> Un único fichero YAML `.github/workflows/pipeline.yml` con un solo job `test`.
+> No crees ni modifiques ningún otro fichero.
+>
+> WARNINGS
+> - El fichero DEBE llamarse `pipeline.yml`, no `ci.yml` (ignora el ci.yml vacío).
+> - Trigger: `pull_request` con tipos `[opened, synchronize, reopened]`
+>   (synchronize = push a rama con PR abierto). No usar `on: push`.
+> - Monorepo: ejecutar en `backend/` vía `defaults.run.working-directory`.
+> - Usar `npm ci` (no `npm install`). Fijar versiones de las actions.
+> - No añadir build ni deploy todavía.
+>
+> REQUISITOS DE CALIDAD
+> - `name` del workflow: "Backend CI/CD".
+> - Cada step con su `name` descriptivo (logs legibles).
+> - `timeout-minutes: 10` en el job.
+>
+> CONTEXT
+> - Backend Node + TS + Express + Prisma. Tests `npm test` (Jest), autocontenidos.
+>   Node LTS 20. Caché npm sobre backend/package-lock.json. Ver CLAUDE.md.
+
+**Validación:** generado correctamente en una sola pasada. Trigger, working-directory,
+npm ci, caché y versiones de actions correctos; `name` del workflow descriptivo,
+steps nombrados y timeout aplicados. Pendiente de validar en CI tras abrir el PR.

--- a/prompts/prompts-CMH.md
+++ b/prompts/prompts-CMH.md
@@ -115,3 +115,45 @@ fichero llegó con toda la indentación desplazada a la derecha (YAML inválido)
 se reajustó la sangría a 2 espacios con las claves raíz sin indentar. Lección:
 en YAML la indentación es sintaxis, validar siempre con linter (extensión YAML
 de VS Code).
+
+## 3. Job de Deploy a EC2 vía AWS SSM
+
+**Objetivo:** añadir un job `deploy` que despliegue el backend en la EC2 usando
+AWS Systems Manager (SSM) Run Command, sin SSH, ejecutándose solo si el build pasa.
+
+**Prompt inicial (Goal / Return Format / Warnings / Context):**
+> GOAL
+> Añade un tercer job `deploy` al workflow que despliegue el backend en EC2 vía
+> AWS SSM Run Command, sin SSH.
+> [...]
+> WARNINGS
+> - needs: build. Autenticar con aws-actions/configure-aws-credentials@v4 leyendo
+>   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION.
+> - Desplegar con `aws ssm send-command` (DocumentName AWS-RunShellScript,
+>   InstanceIds = secret EC2_INSTANCE_ID) ejecutando: git pull + npm ci +
+>   prisma generate + npm run build + pm2 restart lti-backend.
+> - Tras enviar, ESPERAR y FALLAR si el estado final del comando SSM no es Success.
+> - El job no usa working-directory backend (sobreescribir a ".").
+> CONTEXT
+> - La EC2 ya tiene Node 20, git, PM2 y el repo clonado en
+>   /home/ssm-user/AI4Devs-pipeline; proceso PM2 = lti-backend. Región eu-north-1.
+
+**Prompt de ajuste (desplegar la rama del PR en vez de main):**
+> Ajusta solo el job deploy para que el git pull use la rama que disparó el PR
+> (${{ github.head_ref }}) en lugar de main: git fetch origin →
+> git checkout ${{ github.head_ref }} → git pull origin ${{ github.head_ref }}.
+
+**Validación:** generado correctamente. `needs: build` (cadena test→build→deploy),
+configure-aws-credentials@v4 con los secrets, `aws ssm send-command` bien formado,
+y paso de espera con polling cada 10s (máx 5 min) que distingue Success de
+Failed/Cancelled/TimedOut/Undeliverable e imprime StandardErrorContent al fallar.
+Resuelto el gotcha del working-directory (sobreescrito a "." en el job deploy).
+
+**Consideración de arquitectura (PR vs producción):**
+Por requisito explícito del ejercicio, el deploy se ejecuta en el evento
+`pull_request` y despliega la rama del PR (`github.head_ref`), que es coherente con
+el disparador. En un escenario de producción real, el despliegue NO se acoplaría al
+PR: el PR actuaría solo como *quality gate* (tests + build), y el deploy se
+dispararía al mergear a `main` mediante un trigger separado
+(`on: push: branches: [main]`), desplegando únicamente código ya revisado y
+aprobado. Se documenta esta diferencia de forma consciente.

--- a/prompts/prompts-CMH.md
+++ b/prompts/prompts-CMH.md
@@ -1,0 +1,54 @@
+# Prompts — Pipeline CI/CD en GitHub Actions (Proyecto LTI)
+
+**Alumno:** Curro Martínez Hidalgo
+**Rama:** pipeline-CMH
+**Módulo:** 13 — DevSecOps
+**Herramienta de IA utilizada:** Claude Code (ejecución) + Claude (diseño y tutoría)
+
+## ¿Qué encontrarás en este fichero?
+Registro cronológico de los prompts utilizados para generar, paso a paso, el
+pipeline de GitHub Actions del backend del proyecto LTI. Cada sección incluye el
+objetivo del paso, el prompt exacto lanzado a Claude Code y la validación
+realizada sobre el resultado (revisar siempre el output de la IA, no aceptarlo a
+ciegas).
+
+---
+
+## Contexto del proyecto
+- **Backend:** Node.js + TypeScript + Express + Prisma (PostgreSQL).
+- **Tests:** Jest, autocontenidos (mockean Prisma, no requieren BD ni migraciones).
+- **Build:** `npm run build` (`tsc` → `dist/`). `npm start` ejecuta `dist/index.js`
+  y requiere build previo.
+- **Puerto del backend:** 3010.
+- **Trigger requerido:** push a una rama con un Pull Request abierto.
+
+## Decisión de arquitectura — método de despliegue
+Para el deploy a EC2 se valoraron dos opciones:
+
+| Opción | Cómo | Pros | Contras |
+|--------|------|------|---------|
+| **A — AWS SSM Run Command** (elegida) | El runner se autentica en AWS con credenciales IAM y ordena la ejecución de comandos dentro de la EC2 vía Systems Manager | No requiere abrir el puerto 22 a internet; no hay clave SSH privada almacenada en GitHub; auditable; coste 0 (Run Command entra en free tier) | Setup inicial algo mayor (rol IAM + agente SSM en la instancia) |
+| **B — SSH + S3** (solución oficial) | Sube el artefacto a S3 y se conecta por SSH/SCP a la EC2 | Más directo de montar | Expone el puerto 22; obliga a guardar una clave SSH privada como secret; mayor superficie de ataque |
+
+**Se elige la Opción A (SSM)** por alineación con los principios *security-by-design*
+del módulo DevSecOps: menor superficie de ataque, sin secretos SSH de larga vida y
+sin puertos de administración expuestos. Se diverge conscientemente de la solución
+oficial (que usa SSH+S3) tras analizar pros y contras.
+
+**Secrets previstos en GitHub Actions:**
+`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `EC2_INSTANCE_ID`.
+
+---
+
+## 0. Setup del contexto del proyecto
+
+**Objetivo:** que Claude Code conozca el stack, la estructura y los comandos del
+proyecto antes de generar el pipeline, para no repetir el contexto en cada prompt.
+
+**Comando:**
+> /init
+
+**Resultado y validación:**
+Genera `CLAUDE.md` en la raíz con las secciones Commands, Architecture y CI/CD.
+Validado correctamente: detecta backend Node+TS+Prisma+Jest, build `npm run build`,
+te

--- a/prompts/prompts-CMH.md
+++ b/prompts/prompts-CMH.md
@@ -89,3 +89,29 @@ buenas prácticas de legibilidad y robustez.
 **Validación:** generado correctamente en una sola pasada. Trigger, working-directory,
 npm ci, caché y versiones de actions correctos; `name` del workflow descriptivo,
 steps nombrados y timeout aplicados. Pendiente de validar en CI tras abrir el PR.
+
+## 2. Job de Build del backend
+
+**Objetivo:** añadir un job `build` que compile el backend y publique `dist/`
+como artifact para el deploy, ejecutándose solo si los tests pasan.
+
+**Prompt (Goal / Return Format / Warnings / Requisitos de calidad / Context):**
+> GOAL
+> Añade un segundo job `build` al workflow existente que compile el backend y
+> publique el resultado como artifact para un futuro job de deploy.
+> [... resto del prompt usado ...]
+> WARNINGS
+> - No modificar el job `test`. `build` depende de `test` vía `needs: test`.
+> - VM limpia: checkout + setup Node + `npm ci` propios antes de compilar.
+> - Compilar con `npm run build` (genera backend/dist/).
+> - Subir backend/dist con actions/upload-artifact@v4, nombre `backend-dist`.
+> REQUISITOS DE CALIDAD
+> - El `path` de upload-artifact se resuelve desde la raíz: usar `backend/dist`.
+
+**Validación:** lógica correcta — `needs: test` bien aplicado, job autónomo con
+su propio npm ci, build con `npm run build`, artifact `backend-dist` con
+`path: backend/dist` (gotcha de la ruta resuelto). Corrección posterior: el
+fichero llegó con toda la indentación desplazada a la derecha (YAML inválido);
+se reajustó la sangría a 2 espacios con las claves raíz sin indentar. Lección:
+en YAML la indentación es sintaxis, validar siempre con linter (extensión YAML
+de VS Code).


### PR DESCRIPTION
## Entrega — Ejercicio Pipeline GitHub Actions
**Alumno:** Curro Martínez Hidalgo
**Rama:** pipeline-CMH

### ✅ Pipeline ejecutado correctamente
El pipeline se ha ejecutado con éxito (test → build → deploy) en mi fork, donde
están configurados los Secrets de AWS y GitHub Actions. Evidencia con los 3 checks
en verde:

🔗 **PR con la ejecución funcionando:**
https://github.com/curringas/AI4Devs-pipeline/pull/TU_NUMERO_DE_PR

> Nota: el workflow corre en mi fork porque es donde residen los Secrets
> (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION, EC2_INSTANCE_ID) y la
> infraestructura. En este PR contra el repo base, las Actions no se ejecutan al
> no disponer de dichos Secrets.

### Resumen de la solución
- **Trigger:** evento `pull_request` con tipos `[opened, synchronize, reopened]`.
  `synchronize` captura "push a una rama con PR abierto". Se descarta `on: push`.
- **Jobs (cadena test → build → deploy):**
  1. `test` — `npm ci` + `npm test` (Jest).
  2. `build` — `npm run build` (tsc → dist/) + artifact. `needs: test`.
  3. `deploy` — despliegue en EC2 vía **AWS Systems Manager (SSM) Run Command**.
     `needs: build`.

### Decisión de arquitectura: deploy vía SSM (no SSH)
Se despliega con AWS SSM en lugar de SSH+S3 (security-by-design, módulo DevSecOps):
- No se abre el puerto 22 a internet.
- No se almacena ninguna clave SSH privada como secret.
- Administración por permisos IAM (rol en la instancia + usuario IAM de mínimo
  privilegio para el runner), no por credenciales en la máquina.

El runner se autentica con `aws-actions/configure-aws-credentials` y lanza
`aws ssm send-command`. El job espera el resultado y falla si el estado final no es
`Success`, mostrando `StandardErrorContent` para depuración.

### Consideración PR vs producción
Por requisito del ejercicio, el deploy se ejecuta en el evento `pull_request` y
despliega la rama del PR (`github.head_ref`). En producción real, el deploy no se
acoplaría al PR: este sería solo quality gate (tests + build) y el despliegue se
dispararía al mergear a `main`, desplegando solo código revisado.

### Ficheros de la entrega
- `.github/workflows/pipeline.yml`
- `prompts/prompts-CMH.md` (prompts utilizados para generar cada paso)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Backend tests now execute automatically on pull requests

* **Chores**
  * Automated deployment pipeline configured for backend services with EC2 integration
  * Developer documentation and architecture guides added

<!-- end of auto-generated comment: release notes by coderabbit.ai -->