### PR TITLE
DMM: pipeline CI/CD backend → EC2

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -74,7 +74,7 @@ jobs:
           path: build
 
       - name: List downloaded artifacts
-        run: ls -la build/ build/backend/ 2>&1
+        run: ls -la build/ || true
 
       - name: Copy artifacts to EC2
         uses: appleboy/scp-action@v0.1.7
@@ -83,10 +83,10 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           source: |
-            build/backend/dist
-            build/backend/package.json
-            build/backend/package-lock.json
-            build/backend/prisma
+            build/dist
+            build/package.json
+            build/package-lock.json
+            build/prisma
           target: "/home/${{ secrets.EC2_USER }}/app"
 
       - name: Install deps and restart on EC2

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,0 +1,100 @@
+name: CI/CD Pipeline
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Run backend tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test
+
+  build:
+    name: Build backend
+    needs: test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Generate Prisma client
+        run: npx prisma generate
+      - name: Compile TypeScript
+        run: npm run build
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-build
+          path: |
+            backend/dist
+            backend/package.json
+            backend/package-lock.json
+            backend/prisma
+
+  deploy:
+    name: Deploy to EC2
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: backend-build
+          path: build
+
+      - name: Copy artifacts to EC2
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: |
+            build/dist
+            build/package.json
+            build/package-lock.json
+            build/prisma
+          target: "/home/${{ secrets.EC2_USER }}/app"
+
+      - name: Install deps and restart on EC2
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            cd /home/${{ secrets.EC2_USER }}/app
+            npm ci --omit=dev
+            npx prisma generate
+            (pm2 restart backend || pm2 start npm --name backend -- start)
+            pm2 save --force

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -73,6 +73,9 @@ jobs:
           name: backend-build
           path: build
 
+      - name: List downloaded artifacts
+        run: ls -la build/ build/backend/ 2>&1
+
       - name: Copy artifacts to EC2
         uses: appleboy/scp-action@v0.1.7
         with:
@@ -80,10 +83,10 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           source: |
-            build/dist
-            build/package.json
-            build/package-lock.json
-            build/prisma
+            build/backend/dist
+            build/backend/package.json
+            build/backend/package-lock.json
+            build/backend/prisma
           target: "/home/${{ secrets.EC2_USER }}/app"
 
       - name: Install deps and restart on EC2

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -82,11 +82,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          source: |
-            build/dist
-            build/package.json
-            build/package-lock.json
-            build/prisma
+          source: "build/dist,build/package.json,build/package-lock.json,build/prisma"
           target: "/home/${{ secrets.EC2_USER }}/app"
 
       - name: Install deps and restart on EC2

--- a/prompts/prompts-DMM.md
+++ b/prompts/prompts-DMM.md
@@ -1,0 +1,47 @@
+# Prompts iniciales — DMM
+
+Documentación de los prompts utilizados para generar el pipeline de CI/CD definido en `.github/workflows/pipeline.yml`.
+
+El workflow se dispara con un `pull_request` sobre `main` (tipos `opened`, `synchronize`, `reopened`) y ejecuta tres jobs en cadena: `test` → `build` → `deploy`. Las pruebas mockean `@prisma/client`, así que no requieren base de datos en el runner.
+
+## 1 · Tests de backend (job `test`)
+
+> Necesito un job de GitHub Actions llamado `test` que ejecute los tests del backend Express/TypeScript que está en `backend/`. Stack: Node 20, npm, Jest con `ts-jest` (configurado en `backend/jest.config.js`). Las pruebas mockean `@prisma/client`, por lo que NO hace falta base de datos para correrlas. Pasos del job:
+> 1. `actions/checkout@v4`.
+> 2. `actions/setup-node@v4` con `node-version: '20'`, `cache: 'npm'` y `cache-dependency-path: backend/package-lock.json`.
+> 3. `npm ci` con `working-directory: backend`.
+> 4. `npm test` (que ejecuta `jest`).
+>
+> Runner: `ubuntu-latest`. El trigger del workflow es `pull_request` sobre `main` con tipos `opened`, `synchronize`, `reopened`. Usa `defaults.run.working-directory: backend` para no repetir el prefijo en cada step. Devuélveme el YAML listo para pegar en `.github/workflows/pipeline.yml`.
+
+## 2 · Build del backend (job `build`)
+
+> Añade un segundo job llamado `build` en el mismo workflow, con `needs: test`. Runner `ubuntu-latest`, heredando `working-directory: backend` por defecto. Pasos obligatorios:
+> 1. Checkout + setup-node (Node 20, mismo cache npm que en el job de tests).
+> 2. `npm ci`.
+> 3. `npx prisma generate` para producir el cliente en `node_modules/.prisma/client` (necesario en producción).
+> 4. `npm run build` (corre `tsc` y deja el resultado en `backend/dist/`).
+> 5. `actions/upload-artifact@v4` con `name: backend-build` y `path:` en multilínea con cuatro entradas: `backend/dist`, `backend/package.json`, `backend/package-lock.json` y `backend/prisma`. El `prisma/` se incluye para que el job de deploy pueda regenerar el cliente en la EC2.
+>
+> Devuélveme solo el bloque YAML del job `build`, manteniendo el resto del workflow intacto.
+
+## 3 · Deploy en EC2 (job `deploy`)
+
+> Añade un tercer job llamado `deploy` con `needs: build`, runner `ubuntu-latest`, que despliegue el backend en una instancia EC2 Ubuntu/Amazon Linux usando SSH. El proyecto usará PM2 como process manager. Secrets requeridos en el repo: `EC2_HOST` (DNS público o IP), `EC2_USER` (típicamente `ubuntu` o `ec2-user`), `EC2_SSH_KEY` (clave privada PEM completa, con saltos de línea).
+>
+> Pasos del job:
+> 1. `actions/download-artifact@v4` con `name: backend-build` y `path: build`. Tras esto existen en el runner `build/dist`, `build/package.json`, `build/package-lock.json` y `build/prisma`.
+> 2. `appleboy/scp-action@v0.1.7` que copie esos cuatro elementos al directorio `/home/${{ secrets.EC2_USER }}/app` de la EC2 (usa `source` multilínea y `target` con la ruta absoluta).
+> 3. `appleboy/ssh-action@v1.0.3` con `script:` que ejecute en la EC2:
+>    ```
+>    cd /home/${{ secrets.EC2_USER }}/app
+>    npm ci --omit=dev
+>    npx prisma generate
+>    (pm2 restart backend || pm2 start npm --name backend -- start)
+>    pm2 save --force
+>    ```
+>    La forma `(pm2 restart ... || pm2 start ...)` cubre tanto un redeploy (el proceso ya existe) como el primer deploy (aún no hay proceso).
+>
+> Prerrequisitos en la EC2 que NO ejecuta el workflow y deben estar hechos a mano: Node 20 LTS, PM2 global (`npm i -g pm2`), `pm2 startup` configurado, security group con el puerto `3010` abierto (puerto del backend, ver `backend/src/index.ts`) y `22` accesible desde las IPs de GitHub Actions.
+>
+> Devuélveme el bloque YAML del job `deploy`.

--- a/prompts/prompts-DMM.md
+++ b/prompts/prompts-DMM.md
@@ -44,4 +44,6 @@ El workflow se dispara con un `pull_request` sobre `main` (tipos `opened`, `sync
 >
 > Prerrequisitos en la EC2 que NO ejecuta el workflow y deben estar hechos a mano: Node 20 LTS, PM2 global (`npm i -g pm2`), `pm2 startup` configurado, security group con el puerto `3010` abierto (puerto del backend, ver `backend/src/index.ts`) y `22` accesible desde las IPs de GitHub Actions.
 >
+> Importante: usa `source:` en **una sola línea con comas** (no multi-línea con `|`), porque `appleboy/scp-action@v0.1.7` usa `drone-scp` v1.6.14 internamente y no parsea correctamente los valores multi-línea del YAML, produciendo `tar: empty archive`. Formato correcto: `source: "build/dist,build/package.json,build/package-lock.json,build/prisma"`.
+>
 > Devuélveme el bloque YAML del job `deploy`.


### PR DESCRIPTION
## 
> [!IMPORTANT]
>  Esta PR no puede ejecutar el workflow por la limitación de GitHub con PRs cross-fork. La verificación real (3 jobs en verde, deploy en EC2 t3.micro en `us-east-1`) está en:
>  👉 **https://github.com/dmiguelm/AI4Devs-pipeline-DMM/pull/2**


## Resumen

Pipeline de GitHub Actions que se dispara con `pull_request` sobre `main` y encadena tres jobs:

1. **test** — `npm ci` + `npm test` (Jest con ts-jest). Las pruebas mockean Prisma, no necesitan base de datos.
2. **build** — `npm ci` + `npx prisma generate` + `npm run build`. Sube `backend/dist`, `backend/package.json`, `backend/package-lock.json` y `backend/prisma` como artifact `backend-build`.
3. **deploy** — descarga el artifact, lo copia por SCP a la EC2 (`appleboy/scp-action`) y reinicia el proceso con PM2 (`appleboy/ssh-action`).

## Archivos

- `.github/workflows/pipeline.yml` — workflow.
- `prompts/prompts-DMM.md` — los tres prompts en español que documentan cómo se generó cada job.

## Secrets requeridos en el repo

- `EC2_HOST` — IP pública o DNS de la instancia.
- `EC2_USER` — usuario SSH (típicamente `ec2-user` en Amazon Linux o `ubuntu` en Ubuntu).
- `EC2_SSH_KEY` — clave privada PEM completa con saltos de línea.

## Prerrequisitos en la EC2

- Node 20 LTS
- PM2 global (`npm i -g pm2`)
- `pm2 startup` configurado
- Security group: `22` accesible desde tu IP y `3010` abierto al público (puerto del backend, ver `backend/src/index.ts`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated continuous integration and deployment pipeline for improved code quality and faster release cycles

* **Documentation**
  * Added CI/CD pipeline setup documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->